### PR TITLE
Add "Related Organizations" section, with links to the JuliaHealth organization

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -28,6 +28,11 @@
   url = "#support"
   weight = 5
 
+[[main]]
+  name = "Related Organizations"
+  url = "#related-organizations"
+  weight = 6
+
 # Link to a PDF of your resume/CV from the menu.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.
 # [[main]]

--- a/content/home/community.md
+++ b/content/home/community.md
@@ -1,6 +1,6 @@
 +++
 title = "Community"
-
+weight = 5  # Order that this section will appear.
 +++
 
 Please take a moment to read the [Julia Community Standards](https://julialang.org/community/standards/).

--- a/content/home/people.md
+++ b/content/home/people.md
@@ -5,7 +5,7 @@
 widget = "people"  # See https://sourcethemes.com/academic/docs/page-builder/
 headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
-weight = 68  # Order that this section will appear.
+weight = 4  # Order that this section will appear.
 
 title = "Meet the Team"
 subtitle = ""

--- a/content/home/related-organizations.md
+++ b/content/home/related-organizations.md
@@ -1,0 +1,12 @@
++++
+title = "Related Orgs"
+weight = 7  # Order that this section will appear.
++++
+
+If you are interested in medicine, health care, and public health, check out the
+JuliaHealth organization:
+* Website: [https://juliahealth.org](https://juliahealth.org)
+* GitHub: [https://github.com/JuliaHealth](https://github.com/JuliaHealth)
+
+A longer list of Julia organizations related to the life sciences and health
+sciences is available [here](https://juliahealth.org/related-organizations/).

--- a/content/home/support.md
+++ b/content/home/support.md
@@ -6,7 +6,7 @@
 widget = "blank"  # See https://sourcethemes.com/academic/docs/page-builder/
 headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
-weight = 0  # Order that this section will appear.
+weight = 6  # Order that this section will appear.
 
 title = "Support BioJulia"
 subtitle = "Support further development of BioJulia"


### PR DESCRIPTION
@BenJWard @jakobnissen I was wondering if you'd be open to the idea of adding a link to the JuliaHealth organization on the BioJulia website?

I've put together this PR as an example. Definitely feel free to edit the PR, make the links less obtrusive, etc.

Let me know what you think!

---

This pull request:
1. Creates the "Related Organizations" section
2. In the "Related Organizations" section, adds a link to the JuliaHealth organization
3.  In the "Related Organizations" section, adds a link to the page on the JuliaHealth website that has a full list of Julia organizations related to the life sciences and health sciences.

You will notice that this pull request also tweaks some of the weights. This was necessary to make sure that the sections appear in the same order as they currently do on the BioJulia website.